### PR TITLE
feat: Ocultar el boton ver reservas en la pantalla lista de reservas

### DIFF
--- a/src/main/java/com/tallerwebi/config/HibernateConfig.java
+++ b/src/main/java/com/tallerwebi/config/HibernateConfig.java
@@ -21,7 +21,7 @@ public class HibernateConfig {
         dataSource.setUrl("jdbc:mysql://localhost:3306/web_garage");
         dataSource.setSchema("web_garage");
         dataSource.setUsername("root");
-        dataSource.setPassword("root");
+        dataSource.setPassword("Prats1986!");
         return dataSource;
     }
 

--- a/src/main/webapp/WEB-INF/views/thymeleaf/formulario-pago.html
+++ b/src/main/webapp/WEB-INF/views/thymeleaf/formulario-pago.html
@@ -3,12 +3,13 @@
 <html lang="es" xmlns:th="http://www.thymeleaf.org">
 
 <head>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/card/2.5.0/card.min.css">
     <style>
-        body {
+        .body {
             font-family: Arial, sans-serif;
             background-color: #f4f4f4;
             display: flex;
@@ -24,6 +25,10 @@
             border-radius: 10px;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
             width: 400px;
+        }
+
+        .margen-superior{
+            margin-top: 140px;
         }
 
         .payment-form h2 {
@@ -78,9 +83,17 @@
     </style>
 </head>
 
-<body>
 
-    <div class="payment-form">
+
+<head th:replace="layouts/default.html :: head">
+    <th:block th:fragment="propiedadesAdicionales"></th:block>
+</head>
+
+<body class="body">
+
+    <div th:replace="layouts/default.html :: nav"></div>
+
+    <div class="payment-form margen-superior">
         <h2>Pagar con Tarjeta</h2>
         <div id="card-wrapper"></div>
 

--- a/src/main/webapp/WEB-INF/views/thymeleaf/layouts/default.html
+++ b/src/main/webapp/WEB-INF/views/thymeleaf/layouts/default.html
@@ -28,8 +28,10 @@
                     <div th:if="${session.ID == null}">
                         <a th:href="@{'/login'}" type="button" class="btn btn-buscar-estacionamiento">Ingresar</a>
                     </div>
+
                     <div th:if="${session.ID != null}">
-                        <a th:href="@{'/reservas/listar'}" type="button" class="btn ">Ver Reservas</a>
+                        <a th:if="${#request.requestURI != '/reservas/listar'}" th:href="@{'/reservas/listar'}" type="button" class="btn">Ver Reservas</a>
+                        <!-- <a th:href="@{'/reservas/listar'}" type="button" class="btn ">Ver Reservas</a> -->
                         <a th:href="@{'/cerrar-sesion'}" type="button" class="btn ">Cerrar Sesion</a>
                     </div>
 
@@ -39,10 +41,8 @@
 
 
         <div th:fragment="footer">
-
             <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
             <script type="text/javascript" th:src="@{webjars/bootstrap/5.2.0/js/bootstrap.min.js}"></script>
-
         </div>
     </body>
 </html>


### PR DESCRIPTION
Cuando el usuario está logueado y va al listado de reservas, originalmente en el nav mostraba el botón "ver reservas", ahora cuando está en esa vista el botón ya no se muestra.